### PR TITLE
feat: Setting to disable Style Groups

### DIFF
--- a/Classes/DataSource/FontAwesomeIconsDataSource.php
+++ b/Classes/DataSource/FontAwesomeIconsDataSource.php
@@ -46,6 +46,11 @@ class FontAwesomeIconsDataSource extends AbstractDataSource
             }
 
             foreach ($data['styles'] as $style) {
+                // Skip disabled Styles
+                if(isset($this->configuration['disabled'][$style]) && $this->configuration['disabled'][$style]){
+                    continue;
+                }
+                
                 $optionKey = $this->getIconCode($style, $name);
                 $editorOptionValues[$optionKey] = [
                     'label' => $data['label'],

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ VIVOMEDIA:
       version: 5.12.1
 ``` 
 
+### Disable Icon Groups
+You can disable Icon groups (like brands) with the `disabled` setting. 
+```
+VIVOMEDIA:
+  FontAwesome:
+    Icon:
+      disabled:
+        solid: false
+        light: false
+        regular: false
+        brands: true # Disable Brand Icons
+        duotone: false
+```
+
 ## Screenshots
 ![Screenshot](Documentation/Screenshot.png)
 


### PR DESCRIPTION
A new setting to disable icon groups (like brands, or duotone). 

```
VIVOMEDIA:
  FontAwesome:
    Icon:
      disabled:
        solid: false
        light: false
        regular: false
        brands: true # Disable Brand Icons
        duotone: true # Disable Duotone Icons
```